### PR TITLE
Firestore update, delete rules setup + removing plants

### DIFF
--- a/src/components/dashboard/Table/Table.scss
+++ b/src/components/dashboard/Table/Table.scss
@@ -6,6 +6,7 @@
   margin-top: 70px;
 
   .table {
+    text-align: left;
     position: relative;
     margin: auto;
     max-width: 95%;
@@ -34,13 +35,11 @@
 }
 
 .table-btns {
-  text-align: center;
-
   .update-btn,
   .delete-btn {
     border: none;
-    width: 20px;
-    height: 20px;
+    width: 22px;
+    height: 22px;
     border-radius: 5px;
     margin-left: 5px;
   }

--- a/src/components/dashboard/Table/Table.tsx
+++ b/src/components/dashboard/Table/Table.tsx
@@ -18,6 +18,19 @@ export default function Dashboard() {
       });
   }, [currentUser]);
 
+  function removePlant(id: string) {
+    console.log(id);
+    database.plants
+      .doc(id)
+      .delete()
+      .then(() => {
+        console.log("Document successfully deleted!");
+      })
+      .catch(error => {
+        console.error("Error removing document: ", error);
+      });
+  }
+
   return (
     <div className="table-flex-container">
       <Navbar />
@@ -44,7 +57,10 @@ export default function Dashboard() {
                     <button className="update-btn">
                       <i className="bx bxs-calendar-plus"></i>
                     </button>
-                    <button className="delete-btn">
+                    <button
+                      className="delete-btn"
+                      onClick={() => removePlant(plant.id)}
+                    >
                       <i className="bx bxs-trash"></i>
                     </button>
                   </td>


### PR DESCRIPTION
You are now able to remove a plant from the Firestore database from the client-side app. Changes will be reflected in real-time in the application and console.

The update, delete rules have also been set on the Firebase side to handle permissions.