### PR TITLE
managing booleans with useToggle

### DIFF
--- a/src/components/authentication/ForgotPassword/ForgotPassword.tsx
+++ b/src/components/authentication/ForgotPassword/ForgotPassword.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useEffect } from "react";
+import useToggle from "../../../hooks/useToggle";
 import { useAuth } from "../../../contexts/AuthContext";
 import Alert from "../Alert/Alert";
 import { Link } from "react-router-dom";
@@ -8,7 +9,7 @@ export default function ForgotPassword() {
   const { forgotPassword } = useAuth();
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useToggle(false);
 
   useEffect(() => {
     emailRef.current?.focus();

--- a/src/components/authentication/Signin/Signin.tsx
+++ b/src/components/authentication/Signin/Signin.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect } from "react";
+import useToggle from "../../../hooks/useToggle";
 import { useAuth } from "../../../contexts/AuthContext";
 import Alert from "../Alert/Alert";
 import { Link, useHistory } from "react-router-dom";
@@ -8,7 +9,7 @@ export default function Signin() {
   const passwordRef = useRef<HTMLInputElement>(null);
   const { signin } = useAuth();
   const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useToggle(false);
   const history = useHistory();
 
   useEffect(() => {

--- a/src/components/authentication/Signup/Signup.tsx
+++ b/src/components/authentication/Signup/Signup.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import useToggle from "../../../hooks/useToggle";
 import "./Signup.scss";
 import { useAuth } from "../../../contexts/AuthContext";
 import Alert from "../Alert/Alert";
@@ -10,7 +11,7 @@ export default function Signup() {
   const confirmPasswordRef = useRef<HTMLInputElement>(null);
   const { signup } = useAuth();
   const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useToggle(false);
   const history = useHistory();
 
   useEffect(() => {

--- a/src/components/authentication/UpdateProfile/UpdateProfile.tsx
+++ b/src/components/authentication/UpdateProfile/UpdateProfile.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import useToggle from "../../../hooks/useToggle";
 import "./UpdateProfile.scss";
 import { useAuth } from "../../../contexts/AuthContext";
 import Alert from "../Alert/Alert";
@@ -11,7 +12,7 @@ export default function UpdateProfile() {
   const submitRef = useRef<HTMLButtonElement>(null);
   const { currentUser, updatePassword, updateEmail } = useAuth();
   const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useToggle(false);
   const history = useHistory();
 
   useEffect(() => {

--- a/src/components/dashboard/AddPlant/AddPlant.tsx
+++ b/src/components/dashboard/AddPlant/AddPlant.tsx
@@ -7,7 +7,7 @@ import AddPlantForm from "../AddPlantForm/AddPlantForm";
 
 export default function AddPlant() {
   const [modal, setModal] = useState(false);
-  const plantRef = useRef<HTMLInputElement>();
+  const plantRef = useRef<HTMLInputElement>(null);
   const { currentUser } = useAuth();
 
   function handleSubmit(e: React.SyntheticEvent) {

--- a/src/components/dashboard/AddPlant/AddPlant.tsx
+++ b/src/components/dashboard/AddPlant/AddPlant.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
+import useToggle from "../../../hooks/useToggle";
 import "./AddPlant.scss";
 import { database } from "../../../firebase";
 import Modal from "../Modal/Modal";
@@ -6,7 +7,7 @@ import { useAuth } from "../../../contexts/AuthContext";
 import AddPlantForm from "../AddPlantForm/AddPlantForm";
 
 export default function AddPlant() {
-  const [modal, setModal] = useState(false);
+  const [modal, toggleModal] = useToggle(false);
   const plantRef = useRef<HTMLInputElement>(null);
   const { currentUser } = useAuth();
 
@@ -19,19 +20,19 @@ export default function AddPlant() {
       createdAt: database.getCurrentTimestamp(),
       lastUpdated: database.getCurrentTimestamp(),
     });
-    setModal(false);
+    toggleModal(false);
   }
 
   // database.plants.document(plant.id).collection("status");
   return (
     <>
-      <button className="add-plant" onClick={() => setModal(true)}>
+      <button className="add-plant" onClick={() => toggleModal(true)}>
         +
       </button>
       {modal && (
         <Modal>
           <AddPlantForm
-            close={() => setModal(false)}
+            close={() => toggleModal(false)}
             handleSubmit={handleSubmit}
             ref={plantRef}
           />

--- a/src/hooks/useToggle.tsx
+++ b/src/hooks/useToggle.tsx
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+export type Toggle = (arg0: boolean) => void;
+
+export default function useToggle(initialValue: boolean): [boolean, Toggle] {
+  const [value, setValue] = useState(initialValue);
+
+  function toggleValue(value: boolean) {
+    setValue(currentValue =>
+      typeof value === "boolean" ? value : !currentValue
+    );
+  }
+
+  return [value, toggleValue];
+}

--- a/src/hooks/useToggle.tsx
+++ b/src/hooks/useToggle.tsx
@@ -1,15 +1,17 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 
 export type Toggle = (arg0: boolean) => void;
 
 export default function useToggle(initialValue: boolean): [boolean, Toggle] {
   const [value, setValue] = useState(initialValue);
 
-  function toggleValue(value: boolean) {
-    setValue(currentValue =>
-      typeof value === "boolean" ? value : !currentValue
-    );
-  }
+  const toggleValue = useCallback(
+    (value: boolean) =>
+      setValue(currentValue =>
+        typeof value === "boolean" ? value : !currentValue
+      ),
+    [setValue]
+  );
 
   return [value, toggleValue];
 }


### PR DESCRIPTION
By creating a custom `useToggle` hook we will gain the performance benefits of `useCallback`. All booleans being managed by useState are now being managed by `useToggle`. May make some changes in future to enhance the functionality.